### PR TITLE
Update _Store_Token for api auth changes, and add several MDList functions

### DIFF
--- a/MangaDexPy/__init__.py
+++ b/MangaDexPy/__init__.py
@@ -174,6 +174,14 @@ class MangaDex:
         params["manga[]"] = mg.id
         return self._retrieve_pages(f"{self.api}/cover", Cover, call_limit=100, params=params)
 
+    def get_manga_feed(self, mg: Manga, limit: int = 100, params: dict = None, includes: list = None) -> List[Chapter]:
+        """Gets the feed of a specific Manga."""
+        includes = INCLUDE_ALL if not includes else includes
+        params = params or {}
+        if includes:
+            params["includes[]"] = includes
+        return self._retrieve_pages(f"{self.api}/manga/{mg.id}/feed", Chapter, call_limit=100, params=params, limit=limit)
+
     def get_cover(self, uuid: str) -> Cover:
         """Gets a cover with a specific uuid."""
         req = self.session.get(f"{self.api}/cover/{uuid}")

--- a/MangaDexPy/__init__.py
+++ b/MangaDexPy/__init__.py
@@ -104,7 +104,7 @@ class MangaDex:
             self.login_success = True
             self.session_token = resp["token"]["session"]
             self.refresh_token = resp["token"]["refresh"]
-            self.session.headers["Authorization"] = resp["token"]["session"]
+            self.session.headers["Authorization"] = "Bearer " + resp["token"]["session"]
             return True
 
     def get_manga(self, uuid: str, includes: list = None) -> Manga:

--- a/MangaDexPy/mdlist.py
+++ b/MangaDexPy/mdlist.py
@@ -1,6 +1,6 @@
 class MDList:
     """Represents a user created MDList"""
-    __slots__ = ("id", "name", "visibility", "version", "titles", "creator","client")
+    __slots__ = ("id", "name", "visibility", "titles", "creator","client")
 
     def __init__(self, data, client):
         self.id = data.get("id")
@@ -8,7 +8,6 @@ class MDList:
         _rel = data.get("relationships", [])
         self.name = _attrs.get("name")
         self.visibility = _attrs.get("visibility")
-        self.version = _attrs.get("version")
         self.titles = [x["id"] for x in _rel if x["type"] == "manga"]
         self.creator = next((x["id"] for x in _rel if x["type"] == "user"), None)
         self.client = client

--- a/MangaDexPy/mdlist.py
+++ b/MangaDexPy/mdlist.py
@@ -1,0 +1,14 @@
+class MDList:
+    """Represents a user created MDList"""
+    __slots__ = ("id", "name", "visibility", "version", "titles", "creator","client")
+
+    def __init__(self, data, client):
+        self.id = data.get("id")
+        _attrs = data.get("attributes")
+        _rel = data.get("relationships", [])
+        self.name = _attrs.get("name")
+        self.visibility = _attrs.get("visibility")
+        self.version = _attrs.get("version")
+        self.titles = [x["id"] for x in _rel if x["type"] == "manga"]
+        self.creator = next((x["id"] for x in _rel if x["type"] == "user"), None)
+        self.client = client


### PR DESCRIPTION
## Auth changes
MangaDex updated their /auth/ endpoint (in 5.8.0 I believe?). This broke the wrapper's login function as the user would technically be logged in, but would receive 401 errors for any user get functions. (The docs don't reflect this yet and is still on version 5.7.5 as of writing, but digging through the mangadex discord I found all that needed to be done was add "Bearer" before the auth token in the Authorization header for requests).

### MangaDexPy.MDList
_Represents a MangaDex MDList_ 
Yields:

- `id` str
The UUID of the MDList
- `name` str
The name of the MDList
- `visibility` str
Whether the list is public or private
- `titles` Array[str, ...]
A list of UUIDs of each manga added to this MDList.
- `creator` str
The UUID of the user the created the MDList.

### MangaDexPy.MangaDex
`get_MDList()`
_Gets a specified MDList from MangaDex_
_Note that it is only possible to get lists that belong to the user you are logged in as, or if the list is marked as 'public'. Otherwise a 404 not found error will occur._
Returns: A `MDList` object
Raises: `NoContentError` if there is no list with the given UUID, or if the currently logged in user does not have access to view that list. `APIError` for any other generic error.
Arguments: `uuid` of the MDList

`get_MDList_feed()`
_Gets the feed of the specified MDList_
Returns: Array[`Chapter`, ...]
Raises: `NoResultsError` for empty MDLists
Arguments:
  - `uuid` of the MDList to get feed for.
  - `limit`: How many Chapters to retrieve. Each multiple of 100 will make a new request to the API.
  - `params`: Custom dictionary of parameters to pass to the search utility

`get_user_MDList()`
_Gets the currently logged user's MDLists, or a specified user's created MDLists._
As a note, the API docs state that private lists will only be included if you are logged in. Otherwise, only the public lists will be available.
Returns: Array[`MDList`, ...]
Raises: `NoResultsError` for empty MDLists or `NotLoggedInError` if an issue occurs while authenticating.
Arguments:
  - `uuid` of the user to get MDLists from.
  - `limit`: How many MDLists to retrieve. Each multiple of 100 will make a new request to the API.

`get_user_followed_MDList()`
_Gets the currently logged user's followed MDLists_
You must be logged in to use this call.
Returns: Array[`MDList`, ...]
Raises: `NoResultsError` when no objects were found
Arguments: `limit`: How many MDLists to retrieve. Each multiple of 100 will make a new request to the API.

`is_following_MDList()`
_Returns whether the currently logged user is following a specified MDList_
You must be logged in to use this call.
Returns: bool
Raises: `NotLoggedInError` if user is not logged in
Arguments: 
  - `uuid` of the MDList to check


### Some other notes
One known issue while testing this:
-  There exists manga which do not have a "translatedLanguage" attribute, which causes an error to be raised.
- One instance of this is `https://mangadex.org/title/d1c0d3f9-f359-467c-8474-0b2ea8e06f3d/bocchi-sensei-teach-me-mangadex`

Lists are listed on the API as CustomList, but it seems this is an older name.
This should be most, if not all the GET methods related to CustomLists. 
This is my first time make a PR on github, I apologize if there's some oddity while making this.

